### PR TITLE
Fixes invalid markup when using a module class suffix

### DIFF
--- a/tmpl/default.php
+++ b/tmpl/default.php
@@ -13,19 +13,16 @@ $moduleTitle = $module->title;
 $moduleTitle = strtolower($moduleTitle);
 $moduleTitle = preg_replace('/[^a-z0-9]/i', '_', $moduleTitle);
 $moduleSuffix = $params->get('moduleclass_sfx');
+
+// Construct the CSS class string.
+$baseClass = 'julianclock_' . $moduleTitle;
+$classes = $baseClass . ($moduleSuffix ? ' ' . $baseClass . $moduleSuffix : '');
 ?>
 <!-- BEGIN LAYOUT -->
+	<div class="<?php echo $classes; ?>">
+	</div>
+<!-- END LAYOUT -->
 
-<div class="<?php
-echo "julianclock_" . $moduleTitle . '"';
-if ($moduleSuffix) {
-	echo 'class=" ' . $moduleSuffix . '">';
-} else {
-	echo ">";
-}
-?>
-	 </div>
-	 <!-- END LAYOUT -->
 	 <!-- formula derived from https://en.wikipedia.org/wiki/Julian_day -->
 	 <script type="text/javascript" >
 


### PR DESCRIPTION
Adding a module class suffix currently causes invalid markup to be shown.  If the suffix doesn't include a leading space it also causes the clock not to work.

$baseClass is ensures that the JavaScript always has a valid class name to refer to.
If a module class suffix is used it is added using $baseClass as a prefix.
